### PR TITLE
[Fix] 완료 모임 전환 로직 수정

### DIFF
--- a/src/main/java/com/sparta/moit/domain/meeting/repository/MeetingRepositoryImpl.java
+++ b/src/main/java/com/sparta/moit/domain/meeting/repository/MeetingRepositoryImpl.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.sparta.moit.domain.meeting.entity.QCareer.career;
@@ -133,11 +135,18 @@ public class MeetingRepositoryImpl implements MeetingRepositoryCustom {
     @Override
     public List<Meeting> findAllIncompleteMeetingsForHour() {
         LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1);
+        LocalDateTime now = LocalDateTime.now();
+        LocalTime oneHourAgoTime = oneHourAgo.toLocalTime();
+        LocalTime nowTime = now.toLocalTime();
 
         return queryFactory.selectFrom(meeting)
                 .where(isOpenOrFull())
-                /* now() - 1hr <= meetingEndTime < now() */
-                .where(meeting.meetingStartTime.between(oneHourAgo, LocalDateTime.now()))
+                .where(meeting.meetingDate.eq(LocalDate.now()))
+                /* meetingDate가 오늘이고, meetingEndTime이 1시간 전부터 현재까지인 회의 */
+                .where(meeting.meetingEndTime.hour().between(
+                                oneHourAgoTime.getHour(),nowTime.getHour()
+                        )
+                )
                 .fetch();
     }
 


### PR DESCRIPTION
- StartTime과 EndTime이 작성일 기준의 시간이 저장되어, 당일 시간 기준으로 모임을 완료하는 버그
- EndTime 기준으로 시간만 비교하는 방식으로 변경