### PR TITLE
[FIX] add SSL configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - KAKAO_CLIENT_SECRET
       - KAKAO_REDIRECT_URI
       - KAKAO_ADMIN_KEY
+      - SSL_KEY_STORE
+      - SSL_KEY_STORE_PASSWORD
+      - SSL_KEY_STORE_TYPE
     restart: "always"
 #    volumes:
 #      - '/var/log/:/log'

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,9 +17,15 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.data.redis.host=${PROD_REDIS_URL}
 spring.data.redis.port=6379
 
+# SSL configuration
+server.ssl.enabled=true
+server.ssl.key-store=${SSL_KEY_STORE}
+server.ssl.key-store-password=${SSL_KEY_STORE_PASSWORD}
+server.ssl.key-store-type=${SSL_KEY_STORE_TYPE}
+
 # jwt
 jwt.secret.key=${JWT_SECRET_KEY}
-jwt.refresh.token.expire.time=1209600000
+#jwt.refresh.token.expire.time=1209600000
 
 # Naver
 spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID}


### PR DESCRIPTION
[PR] SSL 인증서를 사용해 Spring Boot API의 HTTPS 활성화
- 백엔드 서버 url 변경 후, SSL 인증서 사용
- AS-IS :"https://hhboard.xyz" 
- TO-BE : "https://api.moit.app"

### 변경 사항
**application-dev.properties 수정:**
- Spring Boot API 서버 HTTPS 설정
- Let’s Encrypt SSL 키스토어를 참조하도록 구성

### 영향
- 호환성: 주요 API 클라이언트는 HTTPS URL로 변경만 하면 됨
- 유지보수: 인증서는 Certbot을 통해 자동 갱신(90일 주기)

### 추가 정보
- EC2 에 직접 Certbot 다운로드함.
- EC2 Cron 작업을 설정해 인증서가 90일마다 자동 갱신
- 갱신시 Spring Boot 서버 재시작
