### PR TITLE
백엔드 서비스 외부 포트 80 및 443 바인딩 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - KAKAO_CLIENT_SECRET
       - KAKAO_REDIRECT_URI
       - KAKAO_ADMIN_KEY
+      - SSL_KEY_STORE
+      - SSL_KEY_STORE_PASSWORD
+      - SSL_KEY_STORE_TYPE
     restart: "always"
 #    volumes:
 #      - '/var/log/:/log'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: "moit03/moit:latest"
     ports:
       - "443:8080"
+      - "80:8080"
     environment:
       - PROD_DB_URL
       - PROD_DB_USERNAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   backend:
     image: "moit03/moit:latest"
     ports:
-      - "80:8080"
+      - "443:8080"
     environment:
       - PROD_DB_URL
       - PROD_DB_USERNAME

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,9 +17,15 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.data.redis.host=${PROD_REDIS_URL}
 spring.data.redis.port=6379
 
+# SSL configuration
+server.ssl.enabled=true
+server.ssl.key-store=${SSL_KEY_STORE}
+server.ssl.key-store-password=${SSL_KEY_STORE_PASSWORD}
+server.ssl.key-store-type=${SSL_KEY_STORE_TYPE}
+
 # jwt
 jwt.secret.key=${JWT_SECRET_KEY}
-jwt.refresh.token.expire.time=1209600000
+#jwt.refresh.token.expire.time=1209600000
 
 # Naver
 spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID}


### PR DESCRIPTION
- Docker Compose 파일에서 백엔드 서비스에 대한 외부 포트 바인딩 추가

### 변경 사항
- 외부 포트 443을 내부 포트 8080에 매핑 (HTTPS 지원)

